### PR TITLE
chore: harden pnpm installs

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -17,6 +17,8 @@ runs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      with:
+        version: 10.33.0
 
     - name: Install Foundry
       if: ${{ inputs.install-foundry == 'true' }}

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -17,8 +17,6 @@ runs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      with:
-        version: 10.33.0
 
     - name: Install Foundry
       if: ${{ inputs.install-foundry == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ out/
 
 node_modules/
 
+.pnpm-store/
+
 .env
 
 lcov.info
-
-.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules/
 .env
 
 lcov.info
+
+.pnpm-store/

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-package-lock=true
-
-engine-strict=true
-prefer-frozen-lockfile=true
-frozen-lockfile=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ cache
 coverage
 lib
 node_modules
+.pnpm-store
 out
 .github
 .husky

--- a/package.json
+++ b/package.json
@@ -27,10 +27,9 @@
         "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
         "preinstall": "npx only-allow@1.2.2 pnpm"
     },
-    "packageManager": "pnpm@10.33.0",
     "engines": {
         "node": ">=24",
-        "pnpm": "10.33.0",
+        "pnpm": ">=10.33.0",
         "npm": "use-pnpm",
         "yarn": "use-pnpm"
     },

--- a/package.json
+++ b/package.json
@@ -1,52 +1,53 @@
 {
-    "name": "standard-repo",
-    "description": "Foundry-based library for proposals simulations",
-    "version": "1.0.1",
-    "devDependencies": {
-        "husky": "8.0.3",
-        "prettier": "3.0.0",
-        "prettier-plugin-solidity": "1.2.0",
-        "solhint": "4.0.0"
-    },
-    "keywords": [
-        "blockchain",
-        "ethereum",
-        "forge",
-        "foundry",
-        "smart-contracts",
-        "solidity"
-    ],
-    "scripts": {
-        "clean": "rm -rf cache out",
-        "build": "forge build",
-        "lint": "solhint --config ./.solhintrc {addresses,proposals,utils,test,examples}/**/*.sol",
-        "prettier": "prettier \"**/*\" --ignore-path .prettierignore --list-different",
-        "prettier:write": "prettier \"**/*\" --ignore-path .prettierignore -w",
-        "test": "forge test",
-        "test:coverage": "forge coverage",
-        "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
-        "preinstall": "npx only-allow@1.2.2 pnpm"
-    },
-    "engines": {
-        "node": ">=24",
-        "pnpm": ">=10.33.0",
-        "npm": "use-pnpm",
-        "yarn": "use-pnpm"
-    },
-    "pnpm": {
-        "overrides": {
-            "brace-expansion": ">=2.0.3",
-            "js-yaml": ">=4.1.1",
-            "lodash": ">=4.18.0",
-            "minimatch": ">=5.1.8",
-            "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
-            "brace-expansion@>=2.0.0 <=2.0.1": ">=2.0.2",
-            "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
-            "lodash@<=4.17.23": ">=4.18.0",
-            "lodash@>=4.0.0 <=4.17.22": ">=4.17.23",
-            "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
-            "minimatch@>=5.0.0 <5.1.7": ">=5.1.7",
-            "minimatch@>=5.0.0 <5.1.8": ">=5.1.8"
-        }
+  "name": "standard-repo",
+  "description": "Foundry-based library for proposals simulations",
+  "version": "1.0.1",
+  "devDependencies": {
+    "husky": "8.0.3",
+    "prettier": "3.0.0",
+    "prettier-plugin-solidity": "1.2.0",
+    "solhint": "4.0.0"
+  },
+  "keywords": [
+    "blockchain",
+    "ethereum",
+    "forge",
+    "foundry",
+    "smart-contracts",
+    "solidity"
+  ],
+  "scripts": {
+    "clean": "rm -rf cache out",
+    "build": "forge build",
+    "lint": "solhint --config ./.solhintrc {addresses,proposals,utils,test,examples}/**/*.sol",
+    "prettier": "prettier \"**/*\" --ignore-path .prettierignore --list-different",
+    "prettier:write": "prettier \"**/*\" --ignore-path .prettierignore -w",
+    "test": "forge test",
+    "test:coverage": "forge coverage",
+    "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
+    "preinstall": "npx only-allow@1.2.2 pnpm"
+  },
+  "engines": {
+    "node": ">=24",
+    "pnpm": ">=10.33.0",
+    "npm": "use-pnpm",
+    "yarn": "use-pnpm"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": ">=2.0.3",
+      "js-yaml": ">=4.1.1",
+      "lodash": ">=4.18.0",
+      "minimatch": ">=5.1.8",
+      "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
+      "brace-expansion@>=2.0.0 <=2.0.1": ">=2.0.2",
+      "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
+      "lodash@<=4.17.23": ">=4.18.0",
+      "lodash@>=4.0.0 <=4.17.22": ">=4.17.23",
+      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
+      "minimatch@>=5.0.0 <5.1.7": ">=5.1.7",
+      "minimatch@>=5.0.0 <5.1.8": ">=5.1.8",
+      "fast-uri": ">=3.1.2"
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "clean": "rm -rf cache out",
-    "build": "forge build",
+    "build": "forge build --profile ci",
     "lint": "solhint --config ./.solhintrc {addresses,proposals,utils,test,examples}/**/*.sol",
     "prettier": "prettier \"**/*\" --ignore-path .prettierignore --list-different",
     "prettier:write": "prettier \"**/*\" --ignore-path .prettierignore -w",
@@ -35,19 +35,11 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion": ">=2.0.3",
-      "js-yaml": ">=4.1.1",
-      "lodash": ">=4.18.0",
-      "minimatch": ">=5.1.8",
-      "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
-      "brace-expansion@>=2.0.0 <=2.0.1": ">=2.0.2",
-      "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
-      "lodash@<=4.17.23": ">=4.18.0",
-      "lodash@>=4.0.0 <=4.17.22": ">=4.17.23",
-      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
-      "minimatch@>=5.0.0 <5.1.7": ">=5.1.7",
-      "minimatch@>=5.0.0 <5.1.8": ">=5.1.8",
-      "fast-uri": ">=3.1.2"
+      "brace-expansion": "^2.0.3",
+      "fast-uri": "^3.1.2",
+      "js-yaml": "^4.1.1",
+      "lodash": "^4.18.0",
+      "minimatch": "^5.1.8"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,45 +1,37 @@
 {
-  "name": "standard-repo",
-  "description": "Foundry-based library for proposals simulations",
-  "version": "1.0.1",
-  "devDependencies": {
-    "husky": "8.0.3",
-    "prettier": "3.0.0",
-    "prettier-plugin-solidity": "1.2.0",
-    "solhint": "4.0.0"
-  },
-  "keywords": [
-    "blockchain",
-    "ethereum",
-    "forge",
-    "foundry",
-    "smart-contracts",
-    "solidity"
-  ],
-  "scripts": {
-    "clean": "rm -rf cache out",
-    "build": "forge build --profile ci",
-    "lint": "solhint --config ./.solhintrc {addresses,proposals,utils,test,examples}/**/*.sol",
-    "prettier": "prettier \"**/*\" --ignore-path .prettierignore --list-different",
-    "prettier:write": "prettier \"**/*\" --ignore-path .prettierignore -w",
-    "test": "forge test",
-    "test:coverage": "forge coverage",
-    "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
-    "preinstall": "npx only-allow@1.2.2 pnpm"
-  },
-  "engines": {
-    "node": ">=24",
-    "pnpm": ">=10.33.0",
-    "npm": "use-pnpm",
-    "yarn": "use-pnpm"
-  },
-  "pnpm": {
-    "overrides": {
-      "brace-expansion": "^2.0.3",
-      "fast-uri": "^3.1.2",
-      "js-yaml": "^4.1.1",
-      "lodash": "^4.18.0",
-      "minimatch": "^5.1.8"
-    }
-  }
+    "name": "standard-repo",
+    "description": "Foundry-based library for proposals simulations",
+    "version": "1.0.1",
+    "devDependencies": {
+        "husky": "8.0.3",
+        "prettier": "3.0.0",
+        "prettier-plugin-solidity": "1.2.0",
+        "solhint": "4.0.0"
+    },
+    "keywords": [
+        "blockchain",
+        "ethereum",
+        "forge",
+        "foundry",
+        "smart-contracts",
+        "solidity"
+    ],
+    "scripts": {
+        "clean": "rm -rf cache out",
+        "build": "forge build --profile ci",
+        "lint": "solhint --config ./.solhintrc {addresses,proposals,utils,test,examples}/**/*.sol",
+        "prettier": "prettier \"**/*\" --ignore-path .prettierignore --list-different",
+        "prettier:write": "prettier \"**/*\" --ignore-path .prettierignore -w",
+        "test": "forge test",
+        "test:coverage": "forge coverage",
+        "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
+        "preinstall": "npx only-allow@1.2.2 pnpm"
+    },
+    "engines": {
+        "node": ">=24",
+        "pnpm": ">=10.33.0",
+        "npm": "use-pnpm",
+        "yarn": "use-pnpm"
+    },
+    "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,19 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: '>=2.0.3'
-  js-yaml: '>=4.1.1'
-  lodash: '>=4.18.0'
-  minimatch: '>=5.1.8'
-  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
-  brace-expansion@>=2.0.0 <=2.0.1: '>=2.0.2'
-  js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
-  lodash@<=4.17.23: '>=4.18.0'
-  lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
-  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
-  minimatch@>=5.0.0 <5.1.7: '>=5.1.7'
-  minimatch@>=5.0.0 <5.1.8: '>=5.1.8'
-  fast-uri: '>=3.1.2'
+  brace-expansion: ^2.0.3
+  fast-uri: ^3.1.2
+  js-yaml: ^4.1.1
+  lodash: ^4.18.0
+  minimatch: ^5.1.8
 
 importers:
 
@@ -111,13 +103,11 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -321,9 +311,9 @@ packages:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -538,11 +528,11 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  balanced-match@4.0.4: {}
+  balanced-match@1.0.2: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@2.1.0:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
   cacheable-lookup@7.0.0: {}
 
@@ -630,7 +620,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.5
+      minimatch: 5.1.9
       once: 1.4.0
 
   got@12.6.1:
@@ -720,9 +710,9 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  minimatch@10.2.5:
+  minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   minimatch@>=5.0.0 <5.1.7: '>=5.1.7'
   minimatch@>=5.0.0 <5.1.8: '>=5.1.8'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -198,8 +199,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -513,7 +514,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -616,7 +617,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   form-data-encoder@2.1.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: ^2.0.3
-  fast-uri: ^3.1.2
-  js-yaml: ^4.1.1
-  lodash: ^4.18.0
-  minimatch: ^5.1.8
+  brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
+  fast-uri@>=3.0.0 <3.1.2: ^3.1.2
+  js-yaml@>=4.0.0 <4.1.1: ^4.1.1
+  lodash@<=4.17.23: ^4.18.0
+  minimatch@>=5.0.0 <5.1.8: ^5.1.8
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+minimumReleaseAge: 10080
+preferFrozenLockfile: true
+engineStrict: true
+strictDepBuilds: true
+blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ preferFrozenLockfile: true
 engineStrict: true
 strictDepBuilds: true
 blockExoticSubdeps: true
+overrides:
+  "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3"
+  "fast-uri@>=3.0.0 <3.1.2": "^3.1.2"
+  "js-yaml@>=4.0.0 <4.1.1": "^4.1.1"
+  "lodash@<=4.17.23": "^4.18.0"
+  "minimatch@>=5.0.0 <5.1.8": "^5.1.8"


### PR DESCRIPTION
## Summary

- adds pnpm workspace hardening settings
- allows pnpm versions >=10.33.0 via `engines.pnpm`
- removes the exact `packageManager` pin so pnpm 11 is not forced back to 10.33.0

## Validation

- parsed `package.json` as JSON
- confirmed pnpm reads `minimumReleaseAge` from `pnpm-workspace.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized package manager version to 10.33.0 for consistent build environments
  * Enhanced workspace configuration with stricter build behavior controls
  * Updated build script configuration for CI/CD integration
  * Refined dependency management with updated package override configurations
  * Updated repository settings for build artifact handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OlympusDAO/forge-proposal-simulator/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->